### PR TITLE
Bug fix: invalid IsData instance triggered due to use of abbrev

### DIFF
--- a/CardanoLedgerApi/V1/Contexts.lean
+++ b/CardanoLedgerApi/V1/Contexts.lean
@@ -194,7 +194,18 @@ instance : IsData ScriptPurpose where
        | none => none
   | _ => none
 
-abbrev Withdrawals := List (StakingCredential × Integer)
+def Withdrawals : Type := List (StakingCredential × Integer)
+
+instance : Repr Withdrawals := inferInstanceAs (Repr (List (StakingCredential × Integer)))
+
+/-- BEq instance for Withdrawals -/
+instance : BEq Withdrawals := ⟨List.beq⟩
+
+/-- DecidableEq instance for Withdrawals -/
+instance : DecidableEq Withdrawals := inferInstanceAs (DecidableEq (List (StakingCredential × Integer)))
+
+/-! LawfulBEq instance for Withdrawals -/
+instance : LawfulBEq Withdrawals := inferInstanceAs (LawfulBEq (List (StakingCredential × Integer)))
 
 /- IsData instance for StakingCredential × Integer -/
 instance : IsData (StakingCredential × Integer) where
@@ -216,7 +227,7 @@ def listDataToTxInfoWdrl (xs : List Data) : Option Withdrawals :=
   | [] => some []
   | x :: xs' =>
       match IsData.fromData x, listDataToTxInfoWdrl xs' with
-      | some cred, some rest => cred :: rest
+      | some cred, some rest => some (cred :: rest)
       | _, _ => none
 
 /-- IsData instance for Withdrawals -/
@@ -226,7 +237,18 @@ instance : IsData Withdrawals where
   | Data.List r_wdrwl => listDataToTxInfoWdrl r_wdrwl
   | _ => none
 
-abbrev DatumMap := List (DatumHash × Datum)
+def DatumMap : Type := List (DatumHash × Datum)
+
+instance : Repr DatumMap := inferInstanceAs (Repr (List (DatumHash × Datum)))
+
+/-- BEq instance for DatumMap -/
+instance : BEq DatumMap := ⟨List.beq⟩
+
+/-- DecidableEq instance for DatumMap -/
+instance : DecidableEq DatumMap := inferInstanceAs (DecidableEq (List (DatumHash × Datum)))
+
+/-! LawfulBEq instance for DatumMap -/
+instance : LawfulBEq DatumMap := inferInstanceAs (LawfulBEq (List (DatumHash × Datum)))
 
 /- IsData instance for DatumHash × Datum -/
 instance : IsData (DatumHash × Datum) where
@@ -245,7 +267,7 @@ def listDataToTxInfoData (xs : List Data) : Option DatumMap :=
   | [] => some []
   | x :: xs' =>
       match IsData.fromData x, listDataToTxInfoData xs' with
-      | some d, some rest => d :: rest
+      | some d, some rest => some (d :: rest)
       | _, _ => none
 
 /- IsData instance for DatumMap -/
@@ -394,17 +416,16 @@ def txInfoSignatoriesToListData (xs : List PubKeyHash) : List Data :=
 def listDataToTxInfoSignatories (xs : List Data) : Option (List PubKeyHash) :=
   match xs with
   | [] => some []
-  | Data.B pk :: xs' =>
-      match listDataToTxInfoSignatories xs' with
-      | some rest => pk :: rest
-      | none => none
-  | _ => none
+  | r_pk :: xs' =>
+      match IsData.fromData r_pk, listDataToTxInfoSignatories xs' with
+      | some pk, some rest => pk :: rest
+      | _, _ => none
 
 /-- IsData instance for List PubKeyHash -/
 instance : IsData (List PubKeyHash) where
   toData x := Data.List (txInfoSignatoriesToListData x)
   fromData
-  | Data.List r_sig =>  listDataToTxInfoSignatories r_sig
+  | Data.List r_sig => listDataToTxInfoSignatories r_sig
   | _ => none
 
 

--- a/CardanoLedgerApi/V1/Credential.lean
+++ b/CardanoLedgerApi/V1/Credential.lean
@@ -10,14 +10,51 @@ open PlutusCore.Integer (Integer)
 open Scripts
 
 /-- `PubKeyHash` is an alias to `ByteString` -/
-abbrev PubKeyHash := ByteString
+def PubKeyHash : Type := ByteString
+
+instance : Repr PubKeyHash := inferInstanceAs (Repr ByteString)
+
+instance : Repr PubKeyHash := inferInstanceAs (Repr ByteString)
+
+/-- BEq instance for PubKeyHash -/
+instance : BEq PubKeyHash := inferInstanceAs (BEq ByteString)
+
+/-! LawfulBEq instance for PubKeyHash -/
+instance : LawfulBEq PubKeyHash := inferInstanceAs (LawfulBEq ByteString)
+
+/-- DecidableEq instance for PubKeyHash -/
+instance : DecidableEq PubKeyHash := inferInstanceAs (DecidableEq ByteString)
+
+/-- LT instance for PubKeyHash -/
+instance : LT PubKeyHash := inferInstanceAs (LT ByteString)
+
+/-- DecidableLT instance for TxOutRef -/
+instance : DecidableLT (PubKeyHash) := inferInstanceAs (DecidableLT ByteString)
+
+@[simp] theorem beqPubKeyHash_iff_eq (x y : PubKeyHash) : x == y ↔ x = y := by simp [BEq.beq]
+
+@[simp] theorem beqPubKeyHash_false_iff_not_eq (x y : PubKeyHash) : (x == y) = false ↔ x ≠ y := by simp [BEq.beq]
+
+@[simp] theorem PubKeyHash.lt_irrefl (x : PubKeyHash) : ¬ x < x := by apply ByteString.lt_irrefl
+
+/-- Std.Irrefl instance for PubKeyHash -/
+instance : Std.Irrefl (. < . : PubKeyHash → PubKeyHash → Prop) :=
+  inferInstanceAs (Std.Irrefl (. < . : ByteString → ByteString → Prop))
+
+/-- LE instance for PubKeyHash -/
+instance : LE PubKeyHash := inferInstanceAs (LE ByteString)
+
+/-- DecidableLE instance for PubKeyHash -/
+instance : DecidableLE PubKeyHash := inferInstanceAs (DecidableLE ByteString)
+
+/-- ToString instance for PubKeyHash -/
+instance : ToString PubKeyHash := inferInstanceAs (ToString ByteString)
+
+/-- String to PubKeyHash coercion to mimick OverloadedString in Haskell -/
+instance : Coe String PubKeyHash := inferInstanceAs (Coe String ByteString)
 
 /-- IsData instance for PubKeyHash -/
-instance : IsData PubKeyHash where
-  toData := Data.B
-  fromData
-  | Data.B pk => some pk
-  | _ => none
+instance : IsData PubKeyHash := inferInstanceAs (IsData ByteString)
 
 /--  Credentials required to unlock a transaction output. -/
 inductive Credential where
@@ -88,7 +125,7 @@ instance : DecidableLT Credential := Credential.decLt
 @[simp] theorem ltCredential_same_false (x : Credential) : ltCredential x x = false := by
     cases x <;> simp only [ltCredential, LT.lt] <;> simp <;> apply String.lt_irrefl
 
-theorem Credential.lt_irrefl (x : Credential) : ¬ x < x := by cases x <;> simp [LT.lt]
+@[simp] theorem Credential.lt_irrefl (x : Credential) : ¬ x < x := by cases x <;> simp [LT.lt]
 
 instance : Std.Irrefl (. < . : Credential → Credential → Prop) where
   irrefl := Credential.lt_irrefl

--- a/CardanoLedgerApi/V1/Scripts.lean
+++ b/CardanoLedgerApi/V1/Scripts.lean
@@ -13,23 +13,90 @@ abbrev Datum := Data
 abbrev Redeemer := Data
 
 /-- `ScriptHash` is an alias to `ByteString` -/
-abbrev ScriptHash := ByteString
+def ScriptHash : Type := ByteString
+
+instance : Repr ScriptHash := inferInstanceAs (Repr ByteString)
+
+/-- BEq instance for ScriptHash -/
+instance : BEq ScriptHash := inferInstanceAs (BEq ByteString)
+
+/-! LawfulBEq instance for ScriptHash -/
+instance : LawfulBEq ScriptHash := inferInstanceAs (LawfulBEq ByteString)
+
+/-! DecidableEq instance for ScriptHash -/
+instance : DecidableEq ScriptHash := inferInstanceAs (DecidableEq ByteString)
+
+/-- LT instance for ScriptHash -/
+instance : LT ScriptHash := inferInstanceAs (LT ByteString)
+
+/-- DecidableLT instance for TxOutRef -/
+instance : DecidableLT (ScriptHash) := inferInstanceAs (DecidableLT ByteString)
+
+@[simp] theorem beqScriptHash_iff_eq (x y : ScriptHash) : x == y ↔ x = y := by simp [BEq.beq]
+
+@[simp] theorem beqScriptHash_false_iff_not_eq (x y : ScriptHash) : (x == y) = false ↔ x ≠ y := by simp [BEq.beq]
+
+/-- Std.Irrefl instance for ScriptHash -/
+instance : Std.Irrefl (. < . : ScriptHash → ScriptHash → Prop) :=
+  inferInstanceAs (Std.Irrefl (. < . : ByteString → ByteString → Prop))
+
+/-- LE instance for ScriptHash -/
+instance : LE ScriptHash := inferInstanceAs (LE ByteString)
+
+/-- DecidableLE instance for ScriptHash -/
+instance : DecidableLE ScriptHash := inferInstanceAs (DecidableLE ByteString)
+
+/-- ToString instance for ScriptHash -/
+instance : ToString ScriptHash := inferInstanceAs (ToString ByteString)
+
+/-- String to ScriptHash coercion to mimick OverloadedString in Haskell -/
+instance : Coe String ScriptHash := inferInstanceAs (Coe String ByteString)
 
 /-- IsData instance for ScriptHash -/
-instance : IsData ScriptHash where
-  toData := Data.B
-  fromData
-  | Data.B sh => some sh
-  | _ => none
+instance : IsData ScriptHash := inferInstanceAs (IsData ByteString)
+
 
 /-- `DatumHash` is an alias to `ByteString` -/
-abbrev DatumHash := ByteString
+def DatumHash : Type := ByteString
+
+instance : Repr DatumHash := inferInstanceAs (Repr ByteString)
+
+/-- BEq instance for DatumHash -/
+instance : BEq DatumHash := inferInstanceAs (BEq ByteString)
+
+/-! LawfulBEq instance for DatumHash -/
+instance : LawfulBEq DatumHash := inferInstanceAs (LawfulBEq ByteString)
+
+/-! DecidableEq instance for DatumHash -/
+instance : DecidableEq DatumHash := inferInstanceAs (DecidableEq ByteString)
+
+/-- LT instance for DatumHash -/
+instance : LT DatumHash := inferInstanceAs (LT ByteString)
+
+/-- DecidableLT instance for TxOutRef -/
+instance : DecidableLT (DatumHash) := inferInstanceAs (DecidableLT ByteString)
+
+@[simp] theorem beqDatumHash_iff_eq (x y : DatumHash) : x == y ↔ x = y := by simp [BEq.beq]
+
+@[simp] theorem beqDatumHash_false_iff_not_eq (x y : DatumHash) : (x == y) = false ↔ x ≠ y := by simp [BEq.beq]
+
+/-- Std.Irrefl instance for DatumHash -/
+instance : Std.Irrefl (. < . : DatumHash → DatumHash → Prop) :=
+  inferInstanceAs (Std.Irrefl (. < . : ByteString → ByteString → Prop))
+
+/-- LE instance for DatumHash -/
+instance : LE DatumHash := inferInstanceAs (LE ByteString)
+
+/-- DecidableLE instance for DatumHash -/
+instance : DecidableLE DatumHash := inferInstanceAs (DecidableLE ByteString)
+
+/-- ToString instance for DatumHash -/
+instance : ToString DatumHash := inferInstanceAs (ToString ByteString)
+
+/-- String to DatumHash coercion to mimick OverloadedString in Haskell -/
+instance : Coe String DatumHash := inferInstanceAs (Coe String ByteString)
 
 /-- IsData instance for DatumHash -/
-instance : IsData DatumHash where
-  toData := Data.B
-  fromData
-  | Data.B dh => some dh
-  | _ => none
+instance : IsData DatumHash := inferInstanceAs (IsData ByteString)
 
 end CardanoLedgerApi.V1.Scripts

--- a/CardanoLedgerApi/V1/Tx.lean
+++ b/CardanoLedgerApi/V1/Tx.lean
@@ -15,7 +15,45 @@ open Scripts
 open Value
 
 /-- Transaction ID, i.e. the hash of a transaction. Hashed with BLAKE2b-256. 32 byte. -/
-abbrev TxId := ByteString
+def TxId : Type := ByteString
+
+instance : Repr TxId := inferInstanceAs (Repr ByteString)
+
+/-- BEq instance for TxId -/
+instance : BEq TxId := inferInstanceAs (BEq ByteString)
+
+/-! LawfulBEq instance for TxId -/
+instance : LawfulBEq TxId := inferInstanceAs (LawfulBEq ByteString)
+
+/-! DecidableEq instance for TxId -/
+instance : DecidableEq TxId := inferInstanceAs (DecidableEq ByteString)
+
+/-- LT instance for TxId -/
+instance : LT TxId := inferInstanceAs (LT ByteString)
+
+/-- DecidableLT instance for TxOutRef -/
+instance : DecidableLT (TxId) := inferInstanceAs (DecidableLT ByteString)
+
+@[simp] theorem beqTxId_iff_eq (x y : TxId) : x == y ↔ x = y := by simp [BEq.beq]
+
+@[simp] theorem beqTxId_false_iff_not_eq (x y : TxId) : (x == y) = false ↔ x ≠ y := by simp [BEq.beq]
+
+@[simp] theorem TxId.lt_irrefl (x : TxId) : ¬ x < x := by apply ByteString.lt_irrefl
+
+/-- Std.Irrefl instance for TxId -/
+instance : Std.Irrefl (. < . : TxId → TxId → Prop) := inferInstanceAs (Std.Irrefl (. < . : ByteString → ByteString → Prop))
+
+/-- LE instance for TxId -/
+instance : LE TxId := inferInstanceAs (LE ByteString)
+
+/-- DecidableLE instance for TxId -/
+instance : DecidableLE TxId := inferInstanceAs (DecidableLE ByteString)
+
+/-- ToString instance for TxId -/
+instance : ToString TxId := inferInstanceAs (ToString ByteString)
+
+/-- String to TxId coercion to mimick OverloadedString in Haskell -/
+instance : Coe String TxId := inferInstanceAs (Coe String ByteString)
 
 /-- IsData instance for TxId
     In V1 and V2, TxId is encoded as Data.Constr 0 [Data.B txid]
@@ -44,11 +82,11 @@ instance : BEq TxOutRef := ⟨beqTxOutRef⟩
 /-! DecidableEq instance for TxOutRef -/
 @[simp] theorem beqTxOutRef_iff_eq (x y : TxOutRef) : beqTxOutRef x y ↔ x = y := by
   match x, y with
-  | TxOutRef.mk tid1 idx1, TxOutRef.mk tid2 idx2 => simp [beqTxOutRef]
+  | TxOutRef.mk tid1 idx1, TxOutRef.mk tid2 idx2 => simp [beqTxOutRef, BEq.beq]
 
 @[simp] theorem beqTxOutRef_false_iff_not_eq (x y : TxOutRef) : beqTxOutRef x y = false ↔ x ≠ y := by
   match x, y with
-  | TxOutRef.mk .., TxOutRef.mk .. => simp [beqTxOutRef]
+  | TxOutRef.mk .., TxOutRef.mk .. => simp [beqTxOutRef, BEq.beq]
 
 def TxOutRef.decEq (x y : TxOutRef) : Decidable (Eq x y) :=
   match h:(beqTxOutRef x y) with
@@ -58,7 +96,7 @@ def TxOutRef.decEq (x y : TxOutRef) : Decidable (Eq x y) :=
 instance : DecidableEq TxOutRef := TxOutRef.decEq
 
 /-! LawfulBEq instance for TxOutRef -/
-theorem beqTxOutRef_reflexive (x : TxOutRef) : beqTxOutRef x x = true := by simp [beqTxOutRef]
+theorem beqTxOutRef_reflexive (x : TxOutRef) : beqTxOutRef x x = true := by simp [beqTxOutRef, BEq.beq]
 
 instance : LawfulBEq TxOutRef where
   eq_of_beq {a b} := (beqTxOutRef_iff_eq a b).1
@@ -92,7 +130,7 @@ instance : DecidableLT (TxOutRef) := TxOutRef.decLt
 @[simp] theorem ltTxOutRef_same_false (x : TxOutRef) : ltTxOutRef x x = false := by
   match x with
   | TxOutRef.mk .. =>
-     simp only [ltTxOutRef, LT.lt]; simp <;> constructor
+     simp only [ltTxOutRef, LT.lt, BEq.beq]; simp <;> constructor
      . apply String.le_refl
      . apply Int.lt_irrefl
 
@@ -107,7 +145,7 @@ instance : LE TxOutRef where
   le x y := ¬ (y < x)
 
 /-! DecidableLE instance for TxOutRef -/
-instance : DecidableLE (TxOutRef) :=
+instance : DecidableLE TxOutRef :=
   fun x y => inferInstanceAs (Decidable (¬ (y < x)))
 
 

--- a/CardanoLedgerApi/V1/Value.lean
+++ b/CardanoLedgerApi/V1/Value.lean
@@ -7,8 +7,91 @@ open PlutusCore.Data (Data)
 open PlutusCore.ByteString (ByteString)
 open PlutusCore.Integer (Integer)
 
-abbrev CurrencySymbol := ByteString
-abbrev TokenName := ByteString
+def CurrencySymbol : Type := ByteString
+
+instance : Repr CurrencySymbol := inferInstanceAs (Repr ByteString)
+
+/-- BEq instance for CurrencySymbol -/
+instance : BEq CurrencySymbol := inferInstanceAs (BEq ByteString)
+
+/-! LawfulBEq instance for CurrencySymbol -/
+instance : LawfulBEq CurrencySymbol := inferInstanceAs (LawfulBEq ByteString)
+
+/-! DecidableEq instance for CurrencySymbol -/
+instance : DecidableEq CurrencySymbol := inferInstanceAs (DecidableEq ByteString)
+
+/-- LT instance for CurrencySymbol -/
+instance : LT CurrencySymbol := inferInstanceAs (LT ByteString)
+
+/-- DecidableLT instance for TxOutRef -/
+instance : DecidableLT (CurrencySymbol) := inferInstanceAs (DecidableLT ByteString)
+
+@[simp] theorem beqCurrencySymbol_iff_eq (x y : CurrencySymbol) : x == y ↔ x = y := by simp [BEq.beq]
+
+@[simp] theorem beqCurrencySymbol_false_iff_not_eq (x y : CurrencySymbol) : (x == y) = false ↔ x ≠ y := by simp [BEq.beq]
+
+/-- Std.Irrefl instance for CurrencySymbol -/
+instance : Std.Irrefl (. < . : CurrencySymbol → CurrencySymbol → Prop) :=
+  inferInstanceAs (Std.Irrefl (. < . : ByteString → ByteString → Prop))
+
+/-- LE instance for CurrencySymbol -/
+instance : LE CurrencySymbol := inferInstanceAs (LE ByteString)
+
+/-- DecidableLE instance for CurrencySymbol -/
+instance : DecidableLE CurrencySymbol := inferInstanceAs (DecidableLE ByteString)
+
+/-- ToString instance for CurrencySymbol -/
+instance : ToString CurrencySymbol := inferInstanceAs (ToString ByteString)
+
+/-- String to CurrencySymbol coercion to mimick OverloadedString in Haskell -/
+instance : Coe String CurrencySymbol := inferInstanceAs (Coe String ByteString)
+
+/-- IsData instance for CurrencySymbol -/
+instance : IsData CurrencySymbol := inferInstanceAs (IsData ByteString)
+
+
+def TokenName : Type := ByteString
+
+instance : Repr TokenName := inferInstanceAs (Repr ByteString)
+
+/-- BEq instance for TokenName -/
+instance : BEq TokenName := inferInstanceAs (BEq ByteString)
+
+/-! LawfulBEq instance for TokenName -/
+instance : LawfulBEq TokenName := inferInstanceAs (LawfulBEq ByteString)
+
+/-! DecidableEq instance for TokenName -/
+instance : DecidableEq TokenName := inferInstanceAs (DecidableEq ByteString)
+
+/-- LT instance for TokenName -/
+instance : LT TokenName := inferInstanceAs (LT ByteString)
+
+/-- DecidableLT instance for TxOutRef -/
+instance : DecidableLT (TokenName) := inferInstanceAs (DecidableLT ByteString)
+
+@[simp] theorem beqTokenName_iff_eq (x y : TokenName) : x == y ↔ x = y := by simp [BEq.beq]
+
+@[simp] theorem beqTokenName_false_iff_not_eq (x y : TokenName) : (x == y) = false ↔ x ≠ y := by simp [BEq.beq]
+
+/-- Std.Irrefl instance for TokenName -/
+instance : Std.Irrefl (. < . : TokenName → TokenName → Prop) :=
+  inferInstanceAs (Std.Irrefl (. < . : ByteString → ByteString → Prop))
+
+/-- LE instance for TokenName -/
+instance : LE TokenName := inferInstanceAs (LE ByteString)
+
+/-- DecidableLE instance for TokenName -/
+instance : DecidableLE TokenName := inferInstanceAs (DecidableLE ByteString)
+
+/-- ToString instance for TokenName -/
+instance : ToString TokenName := inferInstanceAs (ToString ByteString)
+
+/-- String to TokenName coercion to mimick OverloadedString in Haskell -/
+instance : Coe String TokenName := inferInstanceAs (Coe String ByteString)
+
+/-- IsData instance for TokenName -/
+instance : IsData TokenName := inferInstanceAs (IsData ByteString)
+
 
 /-- The currency symbol for `Ada` -/
 def adaSymbol : CurrencySymbol := ""
@@ -20,18 +103,21 @@ def adaToken : TokenName := ""
      - predicate validTxOutValue when is specified in a TxOut
      - predicate validMintValue when is specified in txInfoMint
 -/
-abbrev Value := List (Data × Data)
+def Value : Type := List (Data × Data)
+
+instance : Repr Value := inferInstanceAs (Repr (List (Data × Data)))
 
 /-- BEq instance for Value -/
 instance : BEq Value := ⟨List.beq⟩
 
 /-- DecidableEq instance for Value -/
-instance : DecidableEq Value := inferInstanceAs (DecidableEq Value)
+instance : DecidableEq Value := inferInstanceAs (DecidableEq (List (Data × Data)))
 
 /-! LawfulBEq instance for Value -/
-instance : LawfulBEq Value := inferInstanceAs (LawfulBEq Value)
+instance : LawfulBEq Value := inferInstanceAs (LawfulBEq (List (Data × Data)))
 
-/-- IsData instance for ScriptHash -/
+
+/-- IsData instance for Value -/
 instance : IsData Value where
   toData v := Data.Map v
   fromData

--- a/CardanoLedgerApi/V2/Contexts.lean
+++ b/CardanoLedgerApi/V2/Contexts.lean
@@ -76,7 +76,18 @@ instance : IsData TxInInfo where
 
 abbrev ScriptPurpose := V1.Contexts.ScriptPurpose
 
-abbrev Withdrawals := List (StakingCredential × Integer) -- handled as a Data.Map at the Data level for V2
+def Withdrawals : Type := List (StakingCredential × Integer) -- handled as a Data.Map at the Data level for V2
+
+instance : Repr Withdrawals := inferInstanceAs (Repr (List (StakingCredential × Integer)))
+
+/-- BEq instance for Withdrawals -/
+instance : BEq Withdrawals := ⟨List.beq⟩
+
+/-- DecidableEq instance for Withdrawals -/
+instance : DecidableEq Withdrawals := inferInstanceAs (DecidableEq (List (StakingCredential × Integer)))
+
+/-! LawfulBEq instance for Withdrawals -/
+instance : LawfulBEq Withdrawals := inferInstanceAs (LawfulBEq (List (StakingCredential × Integer)))
 
 /-- Return the list `Data × Data` representation for Withdrawals.
     V1->V2: each element in Withdrawals is encoded as Data × Data.
@@ -90,7 +101,7 @@ def listPairDataToTxInfoWdrl (xs : List (Data × Data)) : Option Withdrawals :=
   | [] => some []
   | (d1, Data.I i) :: xs' =>
       match IsData.fromData d1, listPairDataToTxInfoWdrl xs' with
-      | some cred, some rest => (cred, i) :: rest
+      | some cred, some rest => some ((cred, i) :: rest)
       | _, _ => none
   | _ => none
 
@@ -103,7 +114,18 @@ instance : IsData Withdrawals where
   | Data.Map r_wdrwl => listPairDataToTxInfoWdrl r_wdrwl
   | _ => none
 
-abbrev DatumMap := List (DatumHash × Datum) -- handled as a Data.Map at the Data level for V2
+def DatumMap : Type := List (DatumHash × Datum) -- handled as a Data.Map at the Data level for V2
+
+instance : Repr DatumMap := inferInstanceAs (Repr (List (DatumHash × Datum)))
+
+/-- BEq instance for DatumMap -/
+instance : BEq DatumMap := ⟨List.beq⟩
+
+/-- DecidableEq instance for DatumMap -/
+instance : DecidableEq DatumMap := inferInstanceAs (DecidableEq (List (DatumHash × Datum)))
+
+/-! LawfulBEq instance for DatumMap -/
+instance : LawfulBEq DatumMap := inferInstanceAs (LawfulBEq (List (DatumHash × Datum)))
 
 /-- Return the list `Data × Data` representation for DatumMap.
     V1->V2: each element in DatumMap is encoded as a Data × Data.
@@ -115,11 +137,10 @@ def txInfoDataToListPairData (xs : DatumMap) : List (Data × Data):=
 def listPairDataToTxInfoData (xs : List (Data × Data)) : Option DatumMap :=
   match xs with
   | [] => some []
-  | (Data.B dh, d2) :: xs' =>
-      match listPairDataToTxInfoData xs' with
-      | some rest => (dh, d2) :: rest
-      |  _ => none
-  | _ => none
+  | (r_dh, d2) :: xs' =>
+      match IsData.fromData r_dh, listPairDataToTxInfoData xs' with
+      | some dh, some rest => some ((dh, d2) :: rest)
+      | _, _ => none
 
 /- IsData instance for DatumMap
    V1->V2: is encoded as a Data.Map
@@ -130,7 +151,18 @@ instance : IsData DatumMap where
   | Data.Map r_dmap => listPairDataToTxInfoData r_dmap
   | _ => none
 
-abbrev RedeemerMap := List (ScriptPurpose × Redeemer) -- handled as a Data.Map at the Data level
+def RedeemerMap : Type := List (ScriptPurpose × Redeemer) -- handled as a Data.Map at the Data level
+
+instance : Repr RedeemerMap := inferInstanceAs (Repr (List (ScriptPurpose × Redeemer)))
+
+/-- BEq instance for RedeemerMap -/
+instance : BEq RedeemerMap := ⟨List.beq⟩
+
+/-- DecidableEq instance for RedeemerMap -/
+instance : DecidableEq RedeemerMap := inferInstanceAs (DecidableEq (List (ScriptPurpose × Redeemer)))
+
+/-! LawfulBEq instance for RedeemerMap -/
+instance : LawfulBEq RedeemerMap := inferInstanceAs (LawfulBEq (List (ScriptPurpose × Redeemer)))
 
 /-- Return the list `Data × Data` representation for RedeemerMap. -/
 def txInfoRedeemersToListPairData (xs : RedeemerMap) : List (Data × Data) :=
@@ -142,7 +174,7 @@ def listPairDataToTxInfoRedeemers (xs : List (Data × Data)) : Option RedeemerMa
   | [] => some []
   | (d1, d2) :: xs' =>
       match IsData.fromData d1, listPairDataToTxInfoRedeemers xs' with
-      | some purpose, some rest => (purpose, d2) :: rest
+      | some purpose, some rest => some ((purpose, d2) :: rest)
       | _, _ => none
 
 /-- IsData instance for RedeemerMap -/
@@ -909,6 +941,5 @@ def validCertifyingContext (input : CertifyingInput) : Bool :=
   match input.ctx.scriptContextPurpose with
   | .Certifying _ => validScriptContext none input.redeemer input.ctx
   | _ => false
-
 
 end CardanoLedgerApi.V2.Contexts

--- a/CardanoLedgerApi/V3/Contexts.lean
+++ b/CardanoLedgerApi/V3/Contexts.lean
@@ -294,7 +294,19 @@ instance : IsData TxInInfo where
 /-- Unlike V1/V2, MintValue does not contain Ada with zero quantity -/
 abbrev MintValue := V2.Value
 
-abbrev RedeemerMap := List (ScriptPurpose × V2.Redeemer) -- handled as a Data.Map at the Data level
+def RedeemerMap : Type := List (ScriptPurpose × V2.Redeemer) -- handled as a Data.Map at the Data level
+
+instance : Repr RedeemerMap := inferInstanceAs (Repr (List (ScriptPurpose × V2.Redeemer)))
+
+/-- BEq instance for RedeemerMap -/
+instance : BEq RedeemerMap := ⟨List.beq⟩
+
+/-- DecidableEq instance for RedeemerMap -/
+instance : DecidableEq RedeemerMap := inferInstanceAs (DecidableEq (List (ScriptPurpose × V2.Redeemer)))
+
+/-! LawfulBEq instance for RedeemerMap -/
+instance : LawfulBEq RedeemerMap := inferInstanceAs (LawfulBEq (List (ScriptPurpose × V2.Redeemer)))
+
 
 /-- Return the list `Data × Data` representation for RedeemerMap. -/
 def txInfoRedeemersToListPairData (xs : RedeemerMap) : List (Data × Data) :=
@@ -306,7 +318,7 @@ def listPairDataToTxInfoRedeemers (xs : List (Data × Data)) : Option RedeemerMa
   | [] => some []
   | (d1, d2) :: xs' =>
       match IsData.fromData d1, listPairDataToTxInfoRedeemers xs' with
-      | some purpose, some rest => (purpose, d2) :: rest
+      | some purpose, some rest => some ((purpose, d2) :: rest)
       | _, _ => none
 
 /-- IsData instance for RedeemerMap -/
@@ -316,7 +328,18 @@ instance : IsData RedeemerMap where
   | Data.Map r_map => listPairDataToTxInfoRedeemers r_map
   | _ => none
 
-abbrev GovernanceVoteMap := List (GovernanceActionId × Vote) -- handled as a Data.Map at the Data level
+def GovernanceVoteMap : Type := List (GovernanceActionId × Vote) -- handled as a Data.Map at the Data level
+
+instance : Repr GovernanceVoteMap := inferInstanceAs (Repr (List (GovernanceActionId × Vote)))
+
+/-- BEq instance for GovernanceVoteMap -/
+instance : BEq GovernanceVoteMap := ⟨List.beq⟩
+
+/-- DecidableEq instance for GovernanceVoteMap -/
+instance : DecidableEq GovernanceVoteMap := inferInstanceAs (DecidableEq (List (GovernanceActionId × Vote)))
+
+/-! LawfulBEq instance for GovernanceVoteMap -/
+instance : LawfulBEq GovernanceVoteMap := inferInstanceAs (LawfulBEq (List (GovernanceActionId × Vote)))
 
 /-- Return the list `Data × Data` representation for GovernanceVoteMap. -/
 def governanceVoteMapToListPairData (xs : GovernanceVoteMap) : List (Data × Data) :=
@@ -328,7 +351,7 @@ def listPairDataToGovernanceVoteMap (xs : List (Data × Data)) : Option Governan
   | [] => some []
   | (r_action, r_vote) :: xs' =>
       match IsData.fromData r_action, IsData.fromData r_vote, listPairDataToGovernanceVoteMap xs' with
-      | some action, some vote, some rest => (action, vote) :: rest
+      | some action, some vote, some rest => some ((action, vote) :: rest)
       | _, _, _ => none
 
 /-- IsData instance for GovernanceVoteMap -/
@@ -339,7 +362,18 @@ instance : IsData GovernanceVoteMap where
   | _ => none
 
 
-abbrev VoterMap := List (Voter × GovernanceVoteMap) -- handled as a Data.Map at the Data level
+def VoterMap : Type := List (Voter × GovernanceVoteMap) -- handled as a Data.Map at the Data level
+
+instance : Repr VoterMap := inferInstanceAs (Repr (List (Voter × GovernanceVoteMap)))
+
+/-- BEq instance for VoteMap -/
+instance : BEq VoterMap := ⟨List.beq⟩
+
+/-- DecidableEq instance for VoteMap -/
+instance : DecidableEq VoterMap := inferInstanceAs (DecidableEq (List (Voter × GovernanceVoteMap)))
+
+/-! LawfulBEq instance for VoteMap -/
+instance : LawfulBEq VoterMap := inferInstanceAs (LawfulBEq (List (Voter × GovernanceVoteMap)))
 
 /-- Return the list `Data × Data` representation for VoterMap. -/
 def voterMapToListPairData (xs : VoterMap) : List (Data × Data) :=
@@ -351,7 +385,7 @@ def listPairDataToVoterMap (xs : List (Data × Data)) : Option VoterMap :=
   | [] => some []
   | (r_voter, r_governance) :: xs' =>
       match IsData.fromData r_voter, IsData.fromData r_governance, listPairDataToVoterMap xs' with
-      | some voter, some governance, some rest => (voter, governance) :: rest
+      | some voter, some governance, some rest => some ((voter, governance) :: rest)
       | _, _, _ => none
 
 /-- IsData instance for VoterMap -/
@@ -820,8 +854,9 @@ def validMintValue (v : MintValue) : Bool :=
           ( txOutDatumHash ownResolvedInput = some dh ∧
             ¬ ∃ datum : Datum, (dh, datum) ∈ ctx.scriptContextTxInfo.txInfoData )
 
-     2. optDatum = some datum → txOutInlineDatum ownResolvedInput = some datum
-
+     2. optDatum = some datum →
+          ( txOutInlineDatum ownResolvedInput = some datum ∨
+             ( txOutDatumHash ownResolvedInput = some dh ∧ (dh, datum) ∈ ctx.scriptContextTxInfo.txInfoData ) )
      with:
        - optDatum : corresponding to the optional datum of the current spending script.
        - ownResolvedInput : corresponding to the resolved input `TxOut` for the current spending script.
@@ -837,6 +872,7 @@ def validInputDatum (optDatum : Option V2.Datum) (ownResolvedInput : V2.TxOut) (
   | none, .OutputDatumHash dh => V2.findDatum dh ctx.scriptContextTxInfo.txInfoData == none
   | none, .NoOutputDatum => true
   | some datum, .OutputDatum datum' => datum == datum'
+  | some datum, .OutputDatumHash dh => V2.findDatum dh ctx.scriptContextTxInfo.txInfoData == some datum
   | some _, _ => false
 
 /-- [LEDGER-RULE]: Ledger rules for the certificate of the current certifying script (V3).
@@ -1262,6 +1298,5 @@ def validProposingContext (ctx : ScriptContext) : Bool :=
   match ctx.scriptContextScriptInfo with
   | .ProposingScript .. => validScriptContext ctx
   | _ => false
-
 
 end CardanoLedgerApi.V3.Contexts

--- a/CardanoLedgerApi/V3/Governance.lean
+++ b/CardanoLedgerApi/V3/Governance.lean
@@ -94,7 +94,7 @@ instance : DecidableLT Voter := decLtVoter
 @[simp] theorem ltVoter_same_false (x : Voter) : ltVoter x x = false := by
   cases x <;> simp only [ltVoter, LT.lt] <;> simp; apply String.lt_irrefl
 
-theorem Voter_lt_irrefl (x : Voter) : ¬ x < x := by cases x <;> simp [LT.lt]
+@[simp] theorem Voter_lt_irrefl (x : Voter) : ¬ x < x := by cases x <;> simp [LT.lt]
 
 instance : Std.Irrefl (. < . : Voter → Voter → Prop) where
   irrefl := Voter_lt_irrefl
@@ -199,7 +199,7 @@ instance : DecidableLT Vote := decLtVote
 /-! Std.Irrefl instance for Vote -/
 @[simp] theorem ltVote_same_false (x : Vote) : ltVote x x = false := by cases x <;> simp [ltVote]
 
-theorem Vote_lt_irrefl (x : Vote) : ¬ x < x := by cases x <;> simp [LT.lt]
+@[simp] theorem Vote_lt_irrefl (x : Vote) : ¬ x < x := by cases x <;> simp [LT.lt]
 
 instance : Std.Irrefl (. < . : Vote → Vote → Prop) where
   irrefl := Vote_lt_irrefl
@@ -406,7 +406,19 @@ The mapping from parameter IDs to parameters can be found in
 -/
 abbrev ChangedParameters := Data
 
-abbrev Withdrawals := List (V2.Credential × Integer) -- handled as a Data.Map at the Data level
+def Withdrawals : Type := List (V2.Credential × Integer) -- handled as a Data.Map at the Data level
+
+instance : Repr Withdrawals := inferInstanceAs (Repr (List (V2.Credential × Integer)))
+
+/-- BEq instance for Withdrawals -/
+instance : BEq Withdrawals := ⟨List.beq⟩
+
+/-- DecidableEq instance for Withdrawals -/
+instance : DecidableEq Withdrawals := inferInstanceAs (DecidableEq (List (V2.Credential × Integer)))
+
+/-! LawfulBEq instance for Withdrawals -/
+instance : LawfulBEq Withdrawals := inferInstanceAs (LawfulBEq (List (V2.Credential × Integer)))
+
 
 /-- Return the list `Data × Data` representation for Withdrawals. -/
 def withdrawalsToListPairData (xs : Withdrawals) : List (Data × Data) :=
@@ -418,7 +430,7 @@ def listPairDataToWithdrawals (xs : List (Data × Data)) : Option Withdrawals :=
   | [] => some []
   | (d1, Data.I i) :: xs' =>
       match IsData.fromData d1, listPairDataToWithdrawals xs' with
-      | some cred, some rest => (cred, i) :: rest
+      | some cred, some rest => some ((cred, i) :: rest)
       | _, _ => none
   | _ => none
 
@@ -429,7 +441,18 @@ instance : IsData Withdrawals where
   | Data.Map r_wdrwl => listPairDataToWithdrawals r_wdrwl
   | _ => none
 
-abbrev NewCommitteeMembers := List (ColdCommitteeCredential × Integer) -- handled as Data.Map at Data level
+def NewCommitteeMembers : Type := List (ColdCommitteeCredential × Integer) -- handled as Data.Map at Data level
+
+instance : Repr NewCommitteeMembers := inferInstanceAs (Repr (List (V2.Credential × Integer)))
+
+/-- BEq instance for NewCommitteeMembers -/
+instance : BEq NewCommitteeMembers := ⟨List.beq⟩
+
+/-- DecidableEq instance for NewCommitteeMembers -/
+instance : DecidableEq NewCommitteeMembers := inferInstanceAs (DecidableEq (List (V2.Credential × Integer)))
+
+/-! LawfulBEq instance for NewCommitteeMembers -/
+instance : LawfulBEq NewCommitteeMembers := inferInstanceAs (LawfulBEq (List (V2.Credential × Integer)))
 
 /-- Return the list `Data × Data` representation for NewCommitteeMembers. -/
 def newCommitteeToListPairData (xs : NewCommitteeMembers) : List (Data × Data) :=
@@ -441,7 +464,7 @@ def listPairDataToNewCommittee (xs : List (Data × Data)) : Option NewCommitteeM
   | [] => some []
   | (d1, Data.I i) :: xs' =>
       match IsData.fromData d1, listPairDataToNewCommittee xs' with
-      | some cred, some rest => (cred, i) :: rest
+      | some cred, some rest => some ((cred, i) :: rest)
       | _, _ => none
   | _ => none
 
@@ -644,7 +667,7 @@ instance : DecidableLT ProposalProcedure := decLtProposalProcedure
 /-! Std.Irrefl instance for ProposalProcedure -/
 @[simp] theorem ltProposalProcedure_same_false (x : ProposalProcedure) : ltProposalProcedure x x = false := by
   match x with
-  | ProposalProcedure.mk .. => simp [ltProposalProcedure]; apply V1.Credential.Credential.lt_irrefl
+  | ProposalProcedure.mk .. => simp [ltProposalProcedure]
 
 theorem ProposalProcedure_lt_irrefl (x : ProposalProcedure) : ¬ x < x := by cases x <;> simp [LT.lt]
 

--- a/CardanoLedgerApi/V3/Tx.lean
+++ b/CardanoLedgerApi/V3/Tx.lean
@@ -9,16 +9,47 @@ open PlutusCore.Data (Data)
 open PlutusCore.Integer (Integer)
 
 /-- Transaction ID, i.e. the hash of a transaction. Hashed with BLAKE2b-256. 32 byte. -/
-abbrev TxId := ByteString
+def TxId : Type := ByteString
 
-/-- IsData instance for TxId
-    In V3, TxId is encoded as Data.B
--/
-instance : IsData TxId where
-  toData := Data.B
-  fromData
-  | Data.B tid => some tid
-  | _ => none
+instance : Repr TxId := inferInstanceAs (Repr ByteString)
+
+/-- BEq instance for TxId -/
+instance : BEq TxId := inferInstanceAs (BEq ByteString)
+
+/-! DecidableEq instance for TxId -/
+instance : DecidableEq TxId := inferInstanceAs (DecidableEq ByteString)
+
+/-- LT instance for TxId -/
+instance : LT TxId := inferInstanceAs (LT ByteString)
+
+/-- DecidableLT instance for TxOutRef -/
+instance : DecidableLT (TxId) := inferInstanceAs (DecidableLT ByteString)
+
+@[simp] theorem beqTxId_iff_eq (x y : TxId) : x == y ↔ x = y := by simp [BEq.beq]
+
+@[simp] theorem beqTxId_false_iff_not_eq (x y : TxId) : (x == y) = false ↔ x ≠ y := by simp [BEq.beq]
+
+@[simp] theorem TxId.lt_irrefl (x : TxId) : ¬ x < x := by apply ByteString.lt_irrefl
+
+/-- Std.Irrefl instance for TxId -/
+instance : Std.Irrefl (. < . : TxId → TxId → Prop) :=
+  inferInstanceAs (Std.Irrefl (. < . : ByteString → ByteString → Prop))
+
+/-- LE instance for TxId -/
+instance : LE TxId := inferInstanceAs (LE ByteString)
+
+/-- DecidableLE instance for TxId -/
+instance : DecidableLE TxId := inferInstanceAs (DecidableLE ByteString)
+
+/-- ToString instance for TxId -/
+instance : ToString TxId := inferInstanceAs (ToString ByteString)
+
+/-- String to TxId coercion to mimick OverloadedString in Haskell -/
+instance : Coe String TxId := inferInstanceAs (Coe String ByteString)
+
+/-- IsData instance for TxId -/
+instance : IsData TxId := inferInstanceAs (IsData ByteString)
+
 
 /-- A reference to a transaction output.
    This is a pair of a transaction ID (`TxId`), and an index indicating which of the outputs

--- a/CardanoLedgerApi/V3/TxCert.lean
+++ b/CardanoLedgerApi/V3/TxCert.lean
@@ -186,7 +186,7 @@ instance : DecidableLT Delegatee := decLtDelegatee
 @[simp] theorem ltDelegatee_same_false (x : Delegatee) : ltDelegatee x x = false := by
   cases x <;> simp only [ltDelegatee, LT.lt] <;> simp <;> repeat' apply String.le_refl
 
-theorem Delegatee_lt_irrefl (x : Delegatee) : ¬ x < x := by cases x <;> simp [LT.lt]
+@[simp] theorem Delegatee_lt_irrefl (x : Delegatee) : ¬ x < x := by cases x <;> simp [LT.lt]
 
 instance : Std.Irrefl (. < . : Delegatee → Delegatee → Prop) where
   irrefl := Delegatee_lt_irrefl

--- a/Tests/Scripts/HelloWorld/Properties.lean
+++ b/Tests/Scripts/HelloWorld/Properties.lean
@@ -38,7 +38,7 @@ def unsafe_redeemer_imp_successful : Prop :=
     isVoidDatum input →
     isSuccessful (appliedHelloWorld.prop input)
 
-#blaster (gen-cex: 0) (solve-result: 1) [unsafe_redeemer_imp_successful]
+#blaster (gen-cex: 0) (solve-result: 1) (random-seed: 2) [unsafe_redeemer_imp_successful]
 
 -- Counterexample expected: There exists at least one valid SpendingInput for which helloWorld is successful.
 def cannot_break_pwd : Prop :=

--- a/Tests/Scripts/MintingPolicy/Properties.lean
+++ b/Tests/Scripts/MintingPolicy/Properties.lean
@@ -28,20 +28,19 @@ def mintingLogicInWithdrawalMap (pparamsCs : ByteString) (ctx : ScriptContext) :
   | some cred => credentialInWithdrawals cred ctx.scriptContextTxInfo.txInfoWdrl
   | none => false
 
-
 /-- Minting Policy successful → scriptInfo = minting logic is in withdrawal map -/
 theorem minting_policy_success_imp_mintScript_info_withdrawal :
   ∀ (pparamsCs : ByteString) (ctx : ScriptContext),
       validMintingContext ctx →
       isSuccessful (appliedMintingPolicy.prop pparamsCs ctx) →
-      mintingLogicInWithdrawalMap pparamsCs ctx := by blaster
+      mintingLogicInWithdrawalMap pparamsCs ctx := by blaster (random-seed: 1)
 
 /-- Minting logic not present in withdrawal map → Minting Policy must fail -/
 theorem logic_not_in_withdrawal_imp_minting_policy_fail :
   ∀ (pparamsCs : ByteString) (ctx : ScriptContext),
      validMintingContext ctx →
      ¬ mintingLogicInWithdrawalMap pparamsCs ctx →
-     isUnsuccessful (appliedMintingPolicy.prop pparamsCs ctx) := by blaster
+     isUnsuccessful (appliedMintingPolicy.prop pparamsCs ctx) := by blaster (random-seed: 1)
 
 /-- Counterexample expected if minting logic not in withdrawal map when minting policy is successful -/
 def minting_policy_success_imp_logic_not_in_withdrawal : Prop :=

--- a/Tests/Scripts/SellNFT/Properties.lean
+++ b/Tests/Scripts/SellNFT/Properties.lean
@@ -26,9 +26,9 @@ instance : IsData SellDatum where
   | _ => none
 
 
-def sellerIsPaid' (sellDatum : SellDatum) (amount : Integer) (ctx : ScriptContext) : Bool :=
+def sellerIsPaid' (sellDatum : SellDatum) (amount : Integer) (ctx : ScriptContext) : Prop :=
   Recursor.any out in ctx.scriptContextTxInfo.txInfoOutputs =>
-    out.txOutAddress = sellDatum.seller && lovelaceOf out.txOutValue ≥ amount
+    out.txOutAddress = sellDatum.seller ∧ lovelaceOf out.txOutValue ≥ amount
 
 def sellerIsPaid (input : SpendingInput) : Bool :=
   match IsData.fromData input.datum with
@@ -65,14 +65,14 @@ theorem sell_nft_successful_imp_seller_is_paid :
   ∀ (input : SpendingInput),
      validSpendingContext input →
      isSuccessful (appliedSellNFT.prop input) →
-     sellerIsPaid input := by blaster
+     sellerIsPaid input := by blaster (random-seed: 2)
 
 /-- seller is not paid → sell nft errors -/
 theorem seller_not_paid_sell_nft_error :
   ∀ (input : SpendingInput),
      validSpendingContext input →
      ¬ sellerIsPaid input →
-     isUnsuccessful (appliedSellNFT.prop input) := by blaster
+     isUnsuccessful (appliedSellNFT.prop input) := by blaster (random-seed: 4)
 
 
 /-- Counterexample expected as sell nft is vulnerable against multi satisfaction -/
@@ -82,7 +82,7 @@ def success_imp_no_multi_spent : Prop :=
      isSuccessful (appliedSellNFT.prop input) →
      no_multi_spent input
 
-#blaster (gen-cex: 0) (solve-result: 1) [success_imp_no_multi_spent]
+#blaster (gen-cex: 0) (solve-result: 1) (random-seed: 4) [success_imp_no_multi_spent]
 
 /-- Counterexample expected if sell nft is successful when seller is not paid -/
 def seller_not_paid_imp_success : Prop :=
@@ -99,6 +99,6 @@ def cannot_unlock_nft : Prop :=
      validSpendingContext input →
      ¬ isSuccessful (appliedSellNFT.prop input)
 
-#blaster (gen-cex: 0) (solve-result: 1) [cannot_unlock_nft]
+#blaster (gen-cex: 0) (solve-result: 1) (random-seed: 3) [cannot_unlock_nft]
 
 end Tests.Scripts.SellNFT

--- a/Tests/Scripts/SellNFT/Properties.lean
+++ b/Tests/Scripts/SellNFT/Properties.lean
@@ -26,9 +26,9 @@ instance : IsData SellDatum where
   | _ => none
 
 
-def sellerIsPaid' (sellDatum : SellDatum) (amount : Integer) (ctx : ScriptContext) : Prop :=
+def sellerIsPaid' (sellDatum : SellDatum) (amount : Integer) (ctx : ScriptContext) : Bool :=
   Recursor.any out in ctx.scriptContextTxInfo.txInfoOutputs =>
-    out.txOutAddress = sellDatum.seller ∧ lovelaceOf out.txOutValue ≥ amount
+    out.txOutAddress = sellDatum.seller && lovelaceOf out.txOutValue ≥ amount
 
 def sellerIsPaid (input : SpendingInput) : Bool :=
   match IsData.fromData input.datum with
@@ -65,14 +65,14 @@ theorem sell_nft_successful_imp_seller_is_paid :
   ∀ (input : SpendingInput),
      validSpendingContext input →
      isSuccessful (appliedSellNFT.prop input) →
-     sellerIsPaid input := by blaster (random-seed: 2)
+     sellerIsPaid input := by blaster (random-seed: 3)
 
 /-- seller is not paid → sell nft errors -/
 theorem seller_not_paid_sell_nft_error :
   ∀ (input : SpendingInput),
      validSpendingContext input →
      ¬ sellerIsPaid input →
-     isUnsuccessful (appliedSellNFT.prop input) := by blaster (random-seed: 4)
+     isUnsuccessful (appliedSellNFT.prop input) := by blaster (random-seed: 2)
 
 
 /-- Counterexample expected as sell nft is vulnerable against multi satisfaction -/
@@ -82,7 +82,7 @@ def success_imp_no_multi_spent : Prop :=
      isSuccessful (appliedSellNFT.prop input) →
      no_multi_spent input
 
-#blaster (gen-cex: 0) (solve-result: 1) (random-seed: 4) [success_imp_no_multi_spent]
+#blaster (gen-cex: 0) (solve-result: 1) (random-seed: 1) [success_imp_no_multi_spent]
 
 /-- Counterexample expected if sell nft is successful when seller is not paid -/
 def seller_not_paid_imp_success : Prop :=
@@ -99,6 +99,6 @@ def cannot_unlock_nft : Prop :=
      validSpendingContext input →
      ¬ isSuccessful (appliedSellNFT.prop input)
 
-#blaster (gen-cex: 0) (solve-result: 1) (random-seed: 3) [cannot_unlock_nft]
+#blaster (gen-cex: 0) (solve-result: 1) (random-seed: 1) [cannot_unlock_nft]
 
 end Tests.Scripts.SellNFT

--- a/Tests/Scripts/UnlockPIN/Properties.lean
+++ b/Tests/Scripts/UnlockPIN/Properties.lean
@@ -39,7 +39,7 @@ def unsafe_pin_imp_successful : Prop :=
     isVoidDatum input →
     isSuccessful (appliedUnlockPIN.prop input)
 
-#blaster (gen-cex: 0) (solve-result: 1) [unsafe_pin_imp_successful]
+#blaster (gen-cex: 0) (solve-result: 1) (random-seed: 2) [unsafe_pin_imp_successful]
 
 -- Counterexample expected: There exists at least one valid SpendingInput for which unlockPIN is successful.
 def cannot_break_pin : Prop :=

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -15,7 +15,7 @@
    "type": "git",
    "subDir": null,
    "scope": "",
-   "rev": "4ef48606303c45225d3ed2e2a87fc50280a763b7",
+   "rev": "a04042c4b7b19c66e7e6fa5bbcc3b1c985894ed0",
    "name": "PlutusCore",
    "manifestFile": "lake-manifest.json",
    "inputRev": "main",


### PR DESCRIPTION
Fixing IsData instance due to use of abbrev when defining alias types

## Description
This PR addresses the following:
- CardanoLedgerApi
  - [x] Avoid defining alias types using `abbrev` infers wrong `IsData` instances especially when two (or more) alias types are targeting the base type.
  - [x] Bug-fix ledger rule for `validInputDatum`  used in `V3` Context to also cover datum hash present at spending validator utxo
- Test Suite:
   - [x] Adjust test suite via use of (random-seed) to accelerate proof convergence
   
## Checklist
- [x] All theorems valid for each formalization in CI
- [x] All the specified lean file are properly considered when compiling and verifying the formalization
- [x] Self review of the code has been done.
- [x] Reviewer has been requested.
- [x] Reviewer has performed the following tasks
     - [ ] Ensure that all the test cases are still valid
     - [ ] Ensure that each specified lean file is properly considered in the tool chain.