### PR TITLE
CardanoLedgerApi: fix ScriptPurpose and Credential orderings to match the ledger's emission order

### DIFF
--- a/CardanoLedgerApi/V1/Contexts.lean
+++ b/CardanoLedgerApi/V1/Contexts.lean
@@ -121,19 +121,37 @@ instance : LawfulBEq ScriptPurpose where
   rfl {bs} := by simp [BEq.beq]
 
 
+/-- Strict order on the V1/V2 `ScriptPurpose` **in the order the Cardano ledger
+emits `txInfoRedeemers`** (V2; V1 `TxInfo` has no redeemer map), which is NOT the
+Plutus constructor order.
+
+LEDGER CITATION (checkout `cd8b7fab8`): same construction as the V3 case
+(`transTxRedeemers`, `eras/babbage/impl/src/Cardano/Ledger/Babbage/TxInfo.hs:
+217-221` — `unsafeFromList ∘ Map.toList`, no re-sorting), with
+`PlutusPurpose f BabbageEra = AlonzoPlutusPurpose f BabbageEra`
+(`eras/babbage/impl/src/Cardano/Ledger/Babbage/Scripts.hs:61`) whose derived `Ord`
+follows
+
+    AlonzoSpending | AlonzoMinting | AlonzoCertifying | AlonzoRewarding
+
+(`eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs:308-313`), i.e.
+**`Spending < Minting < Certifying < Rewarding`**.  A V2 script executed in the
+Conway era sees `ConwayPlutusPurpose` order instead
+(`Conway/Scripts.hs:202-213`), which restricted to these four kinds is the SAME
+sequence, so the fix is unambiguous across eras.  This is the V1/V2 instance of
+defect D1. -/
 def ltScriptPurpose (x y : ScriptPurpose) : Bool :=
   match x, y with
-  | .Minting cs1, .Minting cs2 => cs1 < cs2
-  | .Minting _, _ => true
   | .Spending tref1, .Spending tref2 => tref1 < tref2
-  | .Spending _, .Minting _ => false
   | .Spending _, _ => true
-  | .Rewarding cred1, .Rewarding cred2 => cred1 < cred2
-  | .Rewarding _, .Minting _
-  | .Rewarding _, .Spending _ => false
-  | .Rewarding _, _ => true
+  | .Minting cs1, .Minting cs2 => cs1 < cs2
+  | .Minting _, .Spending _ => false
+  | .Minting _, _ => true
   | .Certifying cert1, .Certifying cert2 => cert1 < cert2
+  | .Certifying _, .Rewarding _ => true
   | .Certifying _, _ => false
+  | .Rewarding cred1, .Rewarding cred2 => cred1 < cred2
+  | .Rewarding _, _ => false
 
 /-- LT instance for ScriptPurpose -/
 instance : LT ScriptPurpose where

--- a/CardanoLedgerApi/V1/Credential.lean
+++ b/CardanoLedgerApi/V1/Credential.lean
@@ -58,12 +58,37 @@ instance : LawfulBEq Credential where
   rfl {bs} := by simp [BEq.beq]
 
 
+/-- Strict order on `Credential` **in the Cardano ledger's order**, which is NOT
+the Plutus constructor order.
+
+LEDGER CITATION (checkout `cd8b7fab8`): the ledger's `Credential` is
+
+    data Credential (kr :: KeyRole) = ScriptHashObj !ScriptHash | KeyHashObj !(KeyHash kr)
+      deriving (Show, Eq, Generic, Ord)
+
+(`libs/cardano-ledger-core/src/Cardano/Ledger/Credential.hs:96-99`), so its
+derived `Ord` puts **`ScriptHashObj < KeyHashObj`** — the opposite of the Plutus
+declaration order `PubKeyCredential | ScriptCredential` that this function used
+before.  Credential-keyed maps reach `TxInfo` unsorted: `txInfoWdrl =
+transMap transAccountAddress transCoinToLovelace (unWithdrawals …)` with
+`transMap = PV3.unsafeFromList . map … . Map.toList`
+(`eras/conway/impl/src/Cardano/Ledger/Conway/TxInfo.hs:544-546, 692-694`), so
+`validWithdrawals` must use the ledger order or it rejects any real withdrawal map
+mixing script and key credentials (defect D2).
+
+The withdrawal map's ledger key is `AccountAddress = (Network, AccountId
+Credential)` (`libs/cardano-ledger-core/src/Cardano/Ledger/Address.hs:183-191`)
+and Plutus drops the `Network` component; that is harmless because
+`validateWrongNetworkWithdrawal`
+(`eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs:181,384`) forces a
+single network per transaction, on which (`Network`, `Credential`) order restricts
+to `Credential` order. -/
 def ltCredential (x y : Credential) : Bool :=
   match x, y with
   | .PubKeyCredential pk1, .PubKeyCredential pk2 => pk1 < pk2
   | .ScriptCredential sh1, .ScriptCredential sh2 => sh1 < sh2
-  | .PubKeyCredential _, .ScriptCredential _ => true
-  | .ScriptCredential _, .PubKeyCredential _ => false
+  | .ScriptCredential _, .PubKeyCredential _ => true
+  | .PubKeyCredential _, .ScriptCredential _ => false
 
 /-- LT instance for Credential -/
 instance : LT Credential where

--- a/CardanoLedgerApi/V3/Contexts.lean
+++ b/CardanoLedgerApi/V3/Contexts.lean
@@ -63,21 +63,55 @@ instance : LawfulBEq ScriptPurpose where
   rfl {bs} := by simp [BEq.beq]
 
 
+/-- Strict order on `ScriptPurpose` **in the order the Cardano ledger emits
+`txInfoRedeemers`**, which is NOT the Plutus constructor order.
+
+LEDGER CITATION (checkout `cd8b7fab8`).  `txInfoRedeemers` is built by
+`transTxRedeemers = PV2.unsafeFromList <$> mapM (transRedeemerPtr …) (Map.toList
+$ tx ^. witsTxL . rdmrsTxWitsL . unRedeemersL)`
+(`eras/babbage/impl/src/Cardano/Ledger/Babbage/TxInfo.hs:217-221`, used for V3 at
+`eras/conway/impl/src/Cardano/Ledger/Conway/TxInfo.hs:499,512`).  `Map.toList`
+enumerates in `PlutusPurpose AsIx ConwayEra` = `ConwayPlutusPurpose AsIx` order
+and `unsafeFromList` does NOT re-sort, so the emitted key order is the DERIVED
+`Ord` of
+
+    ConwaySpending | ConwayMinting | ConwayCertifying | ConwayRewarding
+                   | ConwayVoting  | ConwayProposing
+
+(`eras/conway/impl/src/Cardano/Ledger/Conway/Scripts.hs:202-213`), i.e.
+**`Spending < Minting < Certifying < Rewarding < Voting < Proposing`** — not the
+Plutus declaration order (`Minting` first) that this function used before.  The
+old order made `validRedeemerMap`, hence `validMintingContext`, UNSATISFIABLE for
+any transaction carrying both a spending and a minting redeemer (defect D1).
+
+INTRA-KIND order is unchanged and agrees with the ledger, because the ledger's
+`AsIx` index is the position in an already-sorted collection and the Plutus key's
+leading component sorts the same way: `Spending` ← `Set.toList txInputs` (`TxIn`
+= (`TxId`,`TxIx`) ≡ `ltTxOutRef`); `Minting` ← the `MultiAsset` policy map
+(`PolicyID` ≡ `CurrencySymbol` bytes); `Rewarding` ← the withdrawal map, whose
+key order is `Credential` (see `V1/Credential.lean`'s `ltCredential`, fixed for
+defect D2) modulo the `Network` component that Plutus drops — harmless because
+`validateWrongNetworkWithdrawal`
+(`eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs:181,384`) forces one
+network per transaction; `Certifying`/`Proposing` compare their `Integer` index
+first, which IS the `AsIx` index; `Voting` ← the `VotingProcedures` map, and the
+ledger's `Voter` `Ord` (`Conway/Governance/Procedures.hs:338-342`) has the same
+constructor order as `ltVoter`. -/
 def ltScriptPurpose (x y : ScriptPurpose) : Bool :=
   match x, y with
-  | .Minting cs1, .Minting cs2 => cs1 < cs2
-  | .Minting _, _ => true
   | .Spending tref1, .Spending tref2 => tref1 < tref2
-  | .Spending _, .Minting _ => false
   | .Spending _, _ => true
-  | .Rewarding cred1, .Rewarding cred2 => cred1 < cred2
-  | .Rewarding _, .Minting _
-  | .Rewarding _, .Spending _ => false
-  | .Rewarding _, _ => true
+  | .Minting cs1, .Minting cs2 => cs1 < cs2
+  | .Minting _, .Spending _ => false
+  | .Minting _, _ => true
   | .Certifying n1 cert1, .Certifying n2 cert2 => n1 < n2 || (n1 == n2 && cert1 < cert2)
-  | .Certifying .., .Voting _
-  | .Certifying .., .Proposing .. => true
-  | .Certifying .., _ => false
+  | .Certifying .., .Spending _
+  | .Certifying .., .Minting _ => false
+  | .Certifying .., _ => true
+  | .Rewarding cred1, .Rewarding cred2 => cred1 < cred2
+  | .Rewarding _, .Voting _
+  | .Rewarding _, .Proposing .. => true
+  | .Rewarding _, _ => false
   | .Voting v1, .Voting v2 => v1 < v2
   | .Voting _, .Proposing .. => true
   | .Voting _, _ => false

--- a/Tests/Basic.lean
+++ b/Tests/Basic.lean
@@ -2,3 +2,5 @@
 import Tests.Functions
 import Tests.Recursor
 import Tests.Scripts
+
+import Tests.LedgerOrdering

--- a/Tests/LedgerOrdering.lean
+++ b/Tests/LedgerOrdering.lean
@@ -1,0 +1,70 @@
+import CardanoLedgerApi.V1.Contexts
+import CardanoLedgerApi.V1.Credential
+import CardanoLedgerApi.V3.Contexts
+
+/-!
+# Regression guards: `ScriptPurpose` / `Credential` orderings
+
+These examples pin the orderings used by `validRedeemerMap` / `validWithdrawals`
+to the order in which the **Cardano ledger** emits the corresponding maps into
+`TxInfo`, which is *not* the Plutus constructor order.  Each of them fails on the
+constructor-order definitions.
+
+Ledger citations (cardano-ledger @ `cd8b7fab8`):
+
+* redeemer map — `transTxRedeemers = unsafeFromList <$> mapM … (Map.toList …)`
+  (`eras/babbage/impl/src/Cardano/Ledger/Babbage/TxInfo.hs:217-221`, used for V3
+  at `eras/conway/impl/src/Cardano/Ledger/Conway/TxInfo.hs:499,512`) does not
+  re-sort, so the key order is the derived `Ord` of `ConwayPlutusPurpose`
+  (`eras/conway/impl/src/Cardano/Ledger/Conway/Scripts.hs:202-213`):
+  `Spending < Minting < Certifying < Rewarding < Voting < Proposing`
+  (V1/V2: `AlonzoPlutusPurpose`,
+  `eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs:308-313`, same sequence
+  restricted to the first four kinds);
+* withdrawal map — `txInfoWdrl = transMap … (unWithdrawals …)`
+  (`eras/conway/impl/src/Cardano/Ledger/Conway/TxInfo.hs:544-546,692-694`) is
+  keyed by `Credential`, whose derived `Ord`
+  (`libs/cardano-ledger-core/src/Cardano/Ledger/Credential.hs:96-99`) is
+  `ScriptHashObj < KeyHashObj`.
+-/
+
+namespace Tests.LedgerOrdering
+
+open CardanoLedgerApi
+
+private def ref : V1.Tx.TxOutRef := ⟨"", 0⟩
+private def ref3 : V3.Tx.TxOutRef := ⟨"", 0⟩
+
+/-! ## V3 `ScriptPurpose`: `Spending < Minting` -/
+
+-- A transaction that both spends and mints emits the spending redeemer first.
+example : V3.Contexts.ltScriptPurpose (.Spending ref3) (.Minting "") = true := by decide
+example : V3.Contexts.ltScriptPurpose (.Minting "") (.Spending ref3) = false := by decide
+
+-- `Certifying < Rewarding`, likewise reversed before.
+private def cert3 : V3.TxCert.TxCert := .TxCertRegStaking (.ScriptCredential "") none
+
+example :
+    V3.Contexts.ltScriptPurpose (.Certifying 0 cert3) (.Rewarding (.ScriptCredential "")) = true := by
+  decide
+example :
+    V3.Contexts.ltScriptPurpose (.Rewarding (.ScriptCredential "")) (.Certifying 0 cert3) = false := by
+  decide
+
+/-! ## V1/V2 `ScriptPurpose`: same defect, `AlonzoPlutusPurpose` order -/
+
+example : V1.Contexts.ltScriptPurpose (.Spending ref) (.Minting "") = true := by decide
+example : V1.Contexts.ltScriptPurpose (.Minting "") (.Spending ref) = false := by decide
+example :
+    V1.Contexts.ltScriptPurpose (.Certifying .DCertGenesis)
+      (.Rewarding (.StakingHash (.PubKeyCredential ""))) = true := by
+  decide
+
+/-! ## `Credential`: `ScriptCredential < PubKeyCredential` -/
+
+example : V1.Credential.ltCredential (.ScriptCredential "") (.PubKeyCredential "") = true := by
+  decide
+example : V1.Credential.ltCredential (.PubKeyCredential "") (.ScriptCredential "") = false := by
+  decide
+
+end Tests.LedgerOrdering


### PR DESCRIPTION
# CardanoLedgerApi: fix ScriptPurpose and Credential orderings to match the ledger's emission order

## Problem

`CardanoLedgerApi` orders `ScriptPurpose` (V1/V2 and V3) and `Credential` in the
**Plutus constructor declaration order**. The Cardano ledger does not emit the
corresponding `TxInfo` maps in that order, and it does not re-sort them. So the
order predicates introduced by #3 (`validRedeemerMap`, `validWithdrawals`, and
everything above them: `validScriptContext`, the per-purpose `valid*Context`
family) do not describe a real `ScriptContext` — they describe an order no node
ever produces.

Two distinct defects:

* **D1 — `ScriptPurpose`.** CLAB had `Minting < Spending < Rewarding <
  Certifying < Voting < Proposing` (V3) and `Minting < Spending < Rewarding <
  Certifying` (V1/V2). The ledger emits `Spending` first.
* **D2 — `Credential`.** CLAB had `PubKeyCredential < ScriptCredential`. The
  ledger's derived `Ord` is the opposite.

## Ledger citations

All references are to `cardano-ledger` @ `cd8b7fab8`, verified from source.

**Redeemer map (D1).** `txInfoRedeemers` is built by

```haskell
transTxRedeemers = PV2.unsafeFromList <$>
  mapM (transRedeemerPtr …) (Map.toList $ tx ^. witsTxL . rdmrsTxWitsL . unRedeemersL)
```

`eras/babbage/impl/src/Cardano/Ledger/Babbage/TxInfo.hs:217-221`, used for V3 at
`eras/conway/impl/src/Cardano/Ledger/Conway/TxInfo.hs:499,512`. `Map.toList`
enumerates in `PlutusPurpose AsIx` order and `unsafeFromList` does **not**
re-sort, so the emitted key order is the derived `Ord` of

```haskell
ConwaySpending | ConwayMinting | ConwayCertifying | ConwayRewarding
               | ConwayVoting  | ConwayProposing
```

(`eras/conway/impl/src/Cardano/Ledger/Conway/Scripts.hs:202-213`), i.e.
**`Spending < Minting < Certifying < Rewarding < Voting < Proposing`**.

For V1/V2, `PlutusPurpose f BabbageEra = AlonzoPlutusPurpose f BabbageEra`
(`eras/babbage/impl/src/Cardano/Ledger/Babbage/Scripts.hs:61`) with

```haskell
AlonzoSpending | AlonzoMinting | AlonzoCertifying | AlonzoRewarding
```

(`eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs:308-313`). The Conway
order restricted to those four kinds is the same sequence, so the fix is
era-robust for a V1/V2 script running in Conway.

**Withdrawal map (D2).** The ledger's credential is

```haskell
data Credential (kr :: KeyRole) = ScriptHashObj !ScriptHash | KeyHashObj !(KeyHash kr)
  deriving (Show, Eq, Generic, Ord)
```

(`libs/cardano-ledger-core/src/Cardano/Ledger/Credential.hs:96-99`), so
**`ScriptHashObj < KeyHashObj`**. Credential-keyed maps reach `TxInfo`
unsorted: `txInfoWdrl = transMap transAccountAddress transCoinToLovelace
(unWithdrawals …)` with `transMap = PV3.unsafeFromList . map … . Map.toList`
(`eras/conway/impl/src/Cardano/Ledger/Conway/TxInfo.hs:544-546,692-694`).

The withdrawal map's ledger key is `AccountAddress = (Network, AccountId
Credential)` (`libs/cardano-ledger-core/src/Cardano/Ledger/Address.hs:183-191`)
and Plutus drops the `Network` component; that is harmless because
`validateWrongNetworkWithdrawal`
(`eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs:181,384`) forces a
single network per transaction, on which `(Network, Credential)` order restricts
to `Credential` order.

## Consequence

D1 is not a cosmetic mismatch: it makes the predicates **unsatisfiable** on a
large, ordinary class of transactions.

Any transaction carrying both a spending redeemer and a minting redeemer — i.e.
every mint whose input side is script-locked, the standard shape for programmable
tokens — is emitted `Spending`-first by the node. Under the old order that
sequence is not ascending, so `validRedeemerMap` is `false`, so
`validMintingContext` is `false` for *every* such context. Consequently every
theorem of the form

```lean
theorem foo (ctx : ScriptContext) : validMintingContext ctx → … → POST
```

is **vacuously true** on exactly the class of transactions it is meant to
constrain — at any proof budget, with no warning to the user. D2 does the same,
more narrowly, to `validWithdrawals` for any withdrawal map that mixes script
and key credentials.

The defect was found by golden-vector auditing: real mainnet-shaped transactions
that both spend and mint were decoded into `ScriptContext`s and checked conjunct
by conjunct against the #3 predicates; `validRedeemerMap` failed on all of them.

## Fix

Correct the two orderings. This is preferred over the alternative of weakening
the predicates to duplicate-freeness: the orders are ledger facts, so correcting
them keeps the precondition as strong as reality permits.

* `CardanoLedgerApi/V3/Contexts.lean` — `ltScriptPurpose` becomes `Spending <
  Minting < Certifying < Rewarding < Voting < Proposing`.
* `CardanoLedgerApi/V1/Contexts.lean` — `ltScriptPurpose` becomes `Spending <
  Minting < Certifying < Rewarding`.
* `CardanoLedgerApi/V1/Credential.lean` — `ltCredential` becomes
  `ScriptCredential < PubKeyCredential`.

Each carries a docstring with the citations above, including the argument that
the **intra-kind** order is unchanged and already agrees with the ledger: the
ledger's `AsIx` index is the position in an already-sorted collection and the
Plutus key's leading component sorts the same way (`Spending` ← `Set.toList
txInputs`; `Minting` ← the `MultiAsset` policy map; `Rewarding` ← the withdrawal
map ordered by `Credential`, now fixed; `Certifying`/`Proposing` compare their
`Integer` index first, which *is* the `AsIx` index; `Voting` ← the
`VotingProcedures` map, whose ledger `Voter` `Ord`
(`Conway/Governance/Procedures.hs:338-342`) matches `ltVoter`).

No other conjunct of any predicate is touched. The only structural change is the
direction of two comparisons.

## Regression guards

`Tests/LedgerOrdering.lean` (imported from `Tests/Basic.lean`) pins the flipped
comparisons with tiny `example`s that **fail on the old definitions**:

* `ltScriptPurpose (.Spending …) (.Minting …) = true` and its converse, V1 and V3
  — the D1 core, the spend+mint transaction class;
* `ltScriptPurpose (.Certifying …) (.Rewarding …) = true` and its converse, V1
  and V3 — the other flipped pair;
* `ltCredential (.ScriptCredential …) (.PubKeyCredential …) = true` and its
  converse — D2.

Nine examples in all, each closed by `decide` (kernel evaluation, no
`ofReduceBool`/`native_decide` axiom). The file header repeats the ledger
citations so the expected values are auditable in place.

## How verified

`lake build CardanoLedgerApi Tests` — green, with the repository's own
dependency pins (unmodified `lake-manifest.json` / `lakefile.lean`).

Negative control: reverting only the three source files to their pre-fix state
and rebuilding `Tests` makes **all nine** guards fail (`decide` evaluates the
proposition to the opposite Boolean), so they genuinely pin the change rather
than restating it.

All existing `lt`/irreflexivity/decidability proofs in the touched files compile
unchanged — the orderings are permutations of one another, so the structural
lemmas are insensitive to the swap. No downstream proof in the repository needed
adaptation.
