### PR TITLE
CardanoLedgerApi: make valueOf SMT-translatable — destructure Data keys before comparing

### DIFF
--- a/CardanoLedgerApi/V1/Value.lean
+++ b/CardanoLedgerApi/V1/Value.lean
@@ -81,8 +81,64 @@ def withoutLovelace (v : Value) : Value :=
 
 /-- Return the quantity for the given currency symbol `cs` and the
     given token name `tn` in Value `v`.
+
+    The `Data` keys are destructured in the match patterns and the comparison is
+    performed on the `ByteString` payloads, so no equality is ever *applied* at
+    type `Data`.  This matters for the SMT toolchain: `Eq`/`BEq` on `Data` go
+    through `eqData`, which lives in a `mutual` block, and a goal that still
+    carries a `Data`-equality application over a symbolic `Value` cannot be
+    translated.  Compare `PlutusCore.Value.lookupDataOuter`, which uses the same
+    shape.
+
+    **The rewrite is a pattern-split of the old condition, entry by entry.**
+    `Data.B` is a constructor, hence injective and disjoint from
+    `Data.Constr`/`Data.Map`/`Data.List`/`Data.I`.  Therefore
+    `Data.B tn = r_tn` holds iff `r_tn` is of the form `Data.B b` with `b = tn`,
+    which is exactly what the `(Data.B r_tn, r_price)` arm tests (with `==`,
+    equivalent to `=` by `LawfulBEq ByteString`); the catch-all arm covers the
+    keys for which the old condition was necessarily `false`, and takes the same
+    `else` branch the old code took.  Behaviour on malformed entries is
+    therefore identical to the old code:
+
+    * `find_token`, key not a `B`: old condition `false`, recurse — new
+      catch-all arm, recurse.
+    * `find_token`, key matches but payload not an `I`: both return `0` and stop
+      scanning.
+    * `visit`, key not a `B` but payload a `Map`: old condition `false`, recurse
+      — new `(_, Data.Map _)` arm, recurse.
+    * `visit`, payload not a `Map`: both fall to the final catch-all and return
+      `0` without scanning the tail.
+
+    See `valueOf_eq_valueOfClassic` for the machine-checked statement of this
+    argument against the previous definition, kept verbatim as `valueOfClassic`.
 -/
 def valueOf (cs : CurrencySymbol) (tn : TokenName) (v : Value) : Integer :=
+  let rec find_token (tns : List (Data × Data)) : Integer :=
+    match tns with
+    | [] => 0
+    | (Data.B r_tn, r_price) :: xs =>
+        if tn == r_tn then
+           match r_price with
+           | Data.I price => price
+           | _ => 0
+        else find_token xs
+    | _ :: xs => find_token xs
+  let rec visit (v : Value) : Integer :=
+    match v with
+    | [] => 0
+    | (Data.B r_cs, Data.Map tokens) :: xs =>
+         if cs == r_cs
+         then find_token tokens
+         else visit xs
+    | (_, Data.Map _) :: xs => visit xs
+    | _ => 0
+  visit v
+
+/-- The previous definition of `valueOf`, kept verbatim so that the
+    SMT-translatability rewrite can be checked against it in the kernel.
+    See `valueOf_eq_valueOfClassic`.  Not exported; it exists only for the proof.
+-/
+private def valueOfClassic (cs : CurrencySymbol) (tn : TokenName) (v : Value) : Integer :=
   let rec find_token (tns : List (Data × Data)) : Integer :=
     match tns with
     | [] => 0
@@ -101,6 +157,53 @@ def valueOf (cs : CurrencySymbol) (tn : TokenName) (v : Value) : Integer :=
          else visit xs
     | _ => 0
   visit v
+
+private theorem valueOf_find_token_eq (tn : TokenName) (tns : List (Data × Data)) :
+    valueOf.find_token tn tns = valueOfClassic.find_token tn tns := by
+  induction tns with
+  | nil => rfl
+  | cons hd xs ih =>
+      obtain ⟨r_tn, r_price⟩ := hd
+      cases r_tn with
+      | B b =>
+          by_cases h : tn = b
+          . subst h
+            simp [valueOf.find_token, valueOfClassic.find_token]
+          . simp [valueOf.find_token, valueOfClassic.find_token, h, ih]
+      | Constr _ _ => simp [valueOf.find_token, valueOfClassic.find_token, ih]
+      | Map _ => simp [valueOf.find_token, valueOfClassic.find_token, ih]
+      | List _ => simp [valueOf.find_token, valueOfClassic.find_token, ih]
+      | I _ => simp [valueOf.find_token, valueOfClassic.find_token, ih]
+
+private theorem valueOf_visit_eq (cs : CurrencySymbol) (tn : TokenName) (v : Value) :
+    valueOf.visit cs tn v = valueOfClassic.visit cs tn v := by
+  induction v with
+  | nil => rfl
+  | cons hd xs ih =>
+      obtain ⟨r_cs, r_price⟩ := hd
+      cases r_price with
+      | Map tokens =>
+          cases r_cs with
+          | B b =>
+              by_cases h : cs = b
+              . subst h
+                simp [valueOf.visit, valueOfClassic.visit, valueOf_find_token_eq]
+              . simp [valueOf.visit, valueOfClassic.visit, h, ih]
+          | Constr _ _ => simp [valueOf.visit, valueOfClassic.visit, ih]
+          | Map _ => simp [valueOf.visit, valueOfClassic.visit, ih]
+          | List _ => simp [valueOf.visit, valueOfClassic.visit, ih]
+          | I _ => simp [valueOf.visit, valueOfClassic.visit, ih]
+      | Constr _ _ => cases r_cs <;> simp [valueOf.visit, valueOfClassic.visit]
+      | List _ => cases r_cs <;> simp [valueOf.visit, valueOfClassic.visit]
+      | I _ => cases r_cs <;> simp [valueOf.visit, valueOfClassic.visit]
+      | B _ => cases r_cs <;> simp [valueOf.visit, valueOfClassic.visit]
+
+/-- **Nothing changed.** The SMT-translatable `valueOf` agrees pointwise with the
+    previous definition (`valueOfClassic`) on *every* `Value`, well-formed or not.
+-/
+theorem valueOf_eq_valueOfClassic (cs : CurrencySymbol) (tn : TokenName) (v : Value) :
+    valueOf cs tn v = valueOfClassic cs tn v :=
+  valueOf_visit_eq cs tn v
 
 
 /-- Add a (positive or negative) quantity of a single token to Value `v`.

--- a/Tests/Basic.lean
+++ b/Tests/Basic.lean
@@ -2,3 +2,4 @@
 import Tests.Functions
 import Tests.Recursor
 import Tests.Scripts
+import Tests.Value

--- a/Tests/Value.lean
+++ b/Tests/Value.lean
@@ -1,0 +1,56 @@
+import CardanoLedgerApi.V1
+
+namespace Tests.Value
+
+open PlutusCore.Data (Data)
+open CardanoLedgerApi.V1.Value
+
+/-! Guards for `valueOf`, which destructures its `Data` keys instead of applying
+    equality at type `Data` (so that the SMT toolchain can translate it).  These
+    exercise the flipped cases: a well-formed hit, a miss, an outer entry whose
+    key is not a `Data.B`, an inner entry whose key is not a `Data.B`, and the
+    malformed-payload cases.
+-/
+
+/-- Well-formed lookup hit. -/
+example : valueOf "c" "t" [(Data.B "c", Data.Map [(Data.B "t", Data.I 7)])] = 7 := by rfl
+
+/-- Well-formed lookup miss (currency symbol absent) still scans the tail. -/
+example :
+    valueOf "c" "t"
+      [ (Data.B "a", Data.Map [(Data.B "t", Data.I 3)]),
+        (Data.B "c", Data.Map [(Data.B "u", Data.I 5), (Data.B "t", Data.I 7)]) ] = 7 := by
+  rfl
+
+/-- Outer entry whose key is not a `Data.B` is skipped, not matched. -/
+example :
+    valueOf "c" "t"
+      [ (Data.I 0, Data.Map [(Data.B "t", Data.I 3)]),
+        (Data.B "c", Data.Map [(Data.B "t", Data.I 7)]) ] = 7 := by
+  rfl
+
+/-- Outer entry whose payload is not a `Data.Map` stops the scan and yields `0`,
+    even though a matching entry follows. -/
+example :
+    valueOf "c" "t"
+      [ (Data.B "a", Data.I 0),
+        (Data.B "c", Data.Map [(Data.B "t", Data.I 7)]) ] = 0 := by
+  rfl
+
+/-- Inner entry whose key is not a `Data.B` is skipped, not matched. -/
+example :
+    valueOf "c" "t"
+      [ (Data.B "c", Data.Map [(Data.I 0, Data.I 3), (Data.B "t", Data.I 7)]) ] = 7 := by
+  rfl
+
+/-- Inner key matches but the payload is not a `Data.I`: `0`, and the scan stops. -/
+example :
+    valueOf "c" "t"
+      [ (Data.B "c", Data.Map [(Data.B "t", Data.B "x"), (Data.B "t", Data.I 7)]) ] = 0 := by
+  rfl
+
+-- The translatable definition agrees with the previous one in the kernel:
+-- only the three standard axioms.
+#print axioms CardanoLedgerApi.V1.Value.valueOf_eq_valueOfClassic
+
+end Tests.Value


### PR DESCRIPTION
# CardanoLedgerApi: make `valueOf` SMT-translatable — destructure `Data` keys before comparing

## Problem

`CardanoLedgerApi.V1.Value.valueOf` is unusable as part of a Blaster proof
obligation whenever the `Value` argument is symbolic. Blaster's SMT translation
aborts with

```
translateRecFun: function body expected for
PlutusCore.Data.PlutusCore.DataInternal.eqData
```

## Mechanism

`Data` (`PlutusCore/Data/Basic.lean`) is a nested inductive, and its `BEq` /
`DecidableEq` instances are implemented by `eqData`, which is declared inside a
Lean `mutual` block. The SMT translator retrieves the body of a recursive
function by name; for a member of a `mutual` block no standalone body is
available, so `translateRecFun` fails. Every `Data`-equality *application* that
survives preprocessing — i.e. one whose arguments are not both
constructor-headed and therefore cannot be reduced away — is a hard translation
failure for the whole query, not a degradation.

`valueOf` had two such applications, and both are reached with a non-constructor
argument as soon as the `Value` is a variable rather than a literal:

* the outer loop `visit` compared `Data.B cs == r_cs` — `BEq Data`;
* the inner loop `find_token` compared `Data.B tn = r_tn` under the
  `DecidableEq Data` instance.

Because `valueOf` is the canonical accessor for a per-asset quantity, this
blocks essentially any Blaster obligation about the value carried by a symbolic
output, input or mint.

## Fix

Destructure the `Data` key *in the match pattern* and compare the `ByteString`
payloads, so that no equality is ever applied at type `Data`. This is exactly
the shape used by `PlutusCore.Value.lookupDataOuter` /`lookupDataInner` in
PlutusCoreBlaster, which translate cleanly today.

```lean
def valueOf (cs : CurrencySymbol) (tn : TokenName) (v : Value) : Integer :=
  let rec find_token (tns : List (Data × Data)) : Integer :=
    match tns with
    | [] => 0
    | (Data.B r_tn, r_price) :: xs =>
        if tn == r_tn then
           match r_price with
           | Data.I price => price
           | _ => 0
        else find_token xs
    | _ :: xs => find_token xs
  let rec visit (v : Value) : Integer :=
    match v with
    | [] => 0
    | (Data.B r_cs, Data.Map tokens) :: xs =>
         if cs == r_cs then find_token tokens else visit xs
    | (_, Data.Map _) :: xs => visit xs
    | _ => 0
  visit v
```

The rewrite is a *pattern-split of the old condition*, not a change of policy on
malformed input. `Data.B` is a constructor, hence injective and disjoint from
the other four, so `Data.B tn = r_tn` holds iff `r_tn` is `Data.B b` with
`b = tn`; the new catch-all arms cover precisely the keys on which the old
condition was necessarily `false`, and take the same `else` branch the old code
took. Entry by entry:

| case | old | new |
| --- | --- | --- |
| `find_token`, key not a `B` | condition `false`, recurse | catch-all arm, recurse |
| `find_token`, key hits, payload not an `I` | `0`, stop scanning | `0`, stop scanning |
| `visit`, key not a `B`, payload a `Map` | condition `false`, recurse | `(_, Data.Map _)` arm, recurse |
| `visit`, payload not a `Map` | `0`, tail not scanned | `0`, tail not scanned |

Note in particular that the two "stop scanning" rows are preserved: the old
definition does *not* skip a malformed hit and keep looking, and neither does
the new one.

## Equivalence

The reviewer does not have to take the table on trust. The previous definition
is kept verbatim as a `private def valueOfClassic`, and

```lean
theorem valueOf_eq_valueOfClassic (cs : CurrencySymbol) (tn : TokenName) (v : Value) :
    valueOf cs tn v = valueOfClassic cs tn v
```

is proved by induction on the outer list with a full case split on the key
constructor and the payload constructor (via two private lemmas on the lifted
`visit` / `find_token`). It is unconditional — it holds on *every* `Value`,
well-formed or not, so no `validTxOutValue` / `validMintValue` side condition is
smuggled in.

```
'CardanoLedgerApi.V1.Value.valueOf_eq_valueOfClassic' depends on axioms:
  [propext, Classical.choice, Quot.sound]
```

`valueOfClassic` is `private`: it is not exported from
`CardanoLedgerApi.V1`/`V2`/`V3` and exists only to anchor the proof.

## Guards

`Tests/Value.lean` (new, imported from `Tests/Basic.lean`) adds six
`example`-level guards discharged by `rfl` — no `native_decide` — covering the
arms the rewrite touches: a well-formed hit, a miss that scans on, an outer
entry whose key is not a `Data.B`, an outer entry whose payload is not a
`Data.Map` (scan stops, `0`, even though a matching entry follows), an inner
entry whose key is not a `Data.B`, and an inner hit whose payload is not a
`Data.I`. The file also `#print axioms` the equivalence theorem, so the axiom
set is checked by CI rather than by a claim in this description.

## Verification

Built against the repository's own pins (`lean-toolchain` v4.24.0,
`lake-manifest.json` unchanged) from a clean worktree off `main`:

```
lake build CardanoLedgerApi Tests
Build completed successfully (356 jobs).
```

Zero errors; all pre-existing `Tests/Scripts/**/Properties.lean` Blaster
obligations still report `✅ Valid` / `✅ Expected Falsified`. No downstream
proof needed adaptation: nothing in the tree unfolds `valueOf` or depends on its
definitional shape — the only other references are the `export` lists in
`CardanoLedgerApi/V1.lean`, `V2.lean` and `V3.lean`, which are unaffected.

A caveat on the reproducer, stated plainly: the measured `translateRecFun`
failure comes from a downstream Blaster obligation over a symbolic `Value`.
Small in-repo probes of the form `valueOf cs tn ((k, Data.Map []) :: xs) = …`
with a symbolic `Data` key are discharged by Blaster under *both* the old and
the new definition — preprocessing eliminates the `Data`-equality application
before translation at that size. The change is therefore justified as removing
a known translation hazard from the library's canonical value accessor, with a
kernel proof that it costs nothing semantically, rather than as a fix
demonstrable by a test inside this repository.

## Relationship to other work

This complements PR #6 but is independent of it: it touches only
`CardanoLedgerApi/V1/Value.lean`, `Tests/Basic.lean` and the new
`Tests/Value.lean`, and can be merged in either order.
